### PR TITLE
Various small improvements

### DIFF
--- a/bin/heatpack.js
+++ b/bin/heatpack.js
@@ -44,8 +44,6 @@ var options = {
 if (!args.force) {
   var code = fs.readFileSync(options.entry).toString()
   if (code.indexOf('React.render') === -1) {
-    console.log("Couldn't find React.render in " + options.entry +
-                ' - assuming it exports a React component.')
     options.alias['theydoitonpurposelynn'] = options.entry
     options.entry = path.join(__dirname, '../dummy.js')
   }

--- a/dummy.js
+++ b/dummy.js
@@ -1,3 +1,17 @@
-var React = require('react')
+var React     = require('react')
 var Component = require('theydoitonpurposelynn')
-React.render(<Component/>, document.querySelector('#app'))
+
+function render(Component) {
+  if (!(Component.type && Component.props)) {
+    Component = <Component />;
+  }
+  React.render(Component, document.querySelector('#app'))
+}
+
+render(Component);
+
+if(module.hot) {
+  module.hot.accept("theydoitonpurposelynn", function() {
+    render(require("theydoitonpurposelynn"));
+  });
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ function excludeJS(absPath) {
 
 module.exports = function config(options) {
   return {
-    devtool: 'eval',
+    devtool: 'cheap-module-eval-source-map',
     entry: [
       'webpack-dev-server/client?http://localhost:' + options.port,
       'webpack/hot/only-dev-server',


### PR DESCRIPTION
### Support for modules which export React elements

This adds support for modules which export React elements:

```
export default (
  <div>
    Hello, world!
  </div>
)
```

Which is nice as it saves us from boilerplate we don't need.

Hot reloading feature is preserved.
### Remove warning

This warning is confusing, it makes me think I'm doing something wrong while I'm
not.
### Use 'cheap-module-eval-source-map' devtool

That works with babel which doesn't preserve line during transforms. This is
also the default for Webpack 2.0.
