### PR TITLE
Add babel-runtime to use async

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "autoprefixer-loader": "^2.0.0",
     "babel-core": "^5.7.2",
     "babel-loader": "^5.3.2",
+    "babel-runtime": "^5.8.19",
     "cjsx-loader": "^2.0.1",
     "coffee-loader": "^0.7.2",
     "coffee-script": "^1.9.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,7 +70,7 @@ module.exports = function config(options) {
     },
     module: {
       loaders: [
-        {test: /\.jsx?$/, loader: 'react-hot!babel?stage=0', exclude: excludeJS},
+        {test: /\.jsx?$/, loader: 'react-hot!babel?stage=0&optional[]=runtime', exclude: excludeJS},
         {test: /\.cjsx$/, loader: 'react-hot!coffee!cjsx', exclude: NODE_MODULES_RE},
         {test: /\.coffee$/, loader: 'coffee', exclude: NODE_MODULES_RE},
         {test: /\.json$/, loader: 'json'},


### PR DESCRIPTION
Hi,

I was using `react-heatpack` to try a component that was using some `async`. Unfortunately, it was not  handled and provoked the error `Uncaught ReferenceError: regeneratorRuntime is not defined` in the browser.

Here is a PR that adds `babel-runtime` dependency to handle it. (https://www.npmjs.com/package/babel-loader)
